### PR TITLE
Relax `anyhow` requirement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "anyhow"
-version = "1.0.62"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1485d4d2cc45e7b201ee3767015c96faa5904387c9d87c6efdd0fb511f12d305"
+checksum = "b9a8f622bcf6ff3df478e9deba3e03e4e04b300f8e6a139e192c05fa3490afc7"
 
 [[package]]
 name = "autocfg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-anyhow = "1.0.62"
+anyhow = "1.0"
 k8s-openapi = { version = "0.15.0", features = ["v1_24"] }
 kubewarden-policy-sdk = "0.6.3"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Do not require a specific patch release.
Also, update to the latest stable release.

Supersedes https://github.com/kubewarden/selinux-psp-policy/pull/28
