### PR TITLE
Bump v0.1.12 policy version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,7 +481,7 @@ checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
 
 [[package]]
 name = "selinux-psp"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "k8s-openapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "selinux-psp"
-version = "0.1.11"
+version = "0.1.12"
 authors = ["Rafael Fernández López <ereslibre@ereslibre.es>"]
 edition = "2018"
 

--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -4,16 +4,16 @@
 #
 # This config can be saved to its default location with:
 #   kwctl scaffold artifacthub > artifacthub-pkg.yml 
-version: 0.1.11
+version: 0.1.12
 name: selinux-psp
 displayName: Selinux PSP
-createdAt: 2023-03-24T16:00:32.364943807Z
+createdAt: 2023-07-10T16:19:45.037972206Z
 description: Replacement for the Kubernetes Pod Security Policy that controls the usage of SELinux
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/selinux-psp-policy
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/selinux-psp:v0.1.11
+  image: ghcr.io/kubewarden/policies/selinux-psp:v0.1.12
 keywords:
 - psp
 - container
@@ -21,13 +21,13 @@ keywords:
 - selinux
 links:
 - name: policy
-  url: https://github.com/kubewarden/selinux-psp-policy/releases/download/v0.1.11/policy.wasm
+  url: https://github.com/kubewarden/selinux-psp-policy/releases/download/v0.1.12/policy.wasm
 - name: source
   url: https://github.com/kubewarden/selinux-psp-policy
 install: |
   The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl):
   ```console
-  kwctl pull ghcr.io/kubewarden/policies/selinux-psp:v0.1.11
+  kwctl pull ghcr.io/kubewarden/policies/selinux-psp:v0.1.12
   ```
 maintainers:
 - name: Kubewarden developers


### PR DESCRIPTION
Bump v0.1.12 policy version.        

Updates files bumping the policy version to v0.1.12

Related to https://github.com/kubewarden/kubewarden-controller/issues/479
